### PR TITLE
Fix some linter warnings

### DIFF
--- a/controllers/configuration/backend/s3_test.go
+++ b/controllers/configuration/backend/s3_test.go
@@ -19,7 +19,7 @@ package backend
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -127,18 +127,16 @@ func (s *mockS3Client) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput,
 	}
 
 	if resp != "" {
-		body := ioutil.NopCloser(bytes.NewBuffer([]byte(resp)))
+		body := io.NopCloser(bytes.NewBuffer([]byte(resp)))
 		return &s3.GetObjectOutput{Body: body}, nil
 	}
 	return nil, nil
 }
 
 func (s *mockS3Client) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
-	switch {
-	case *(input.Bucket) == "a" && *(input.Key) == "a":
+	if *(input.Bucket) == "a" && *(input.Key) == "a" {
 		return &s3.DeleteObjectOutput{}, nil
 	}
-
 	return nil, nil
 }
 

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -24,11 +24,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -58,7 +57,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	credentials, err := json.Marshal(&ak)
 	assert.Nil(t, err)
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "default",
 			Namespace: "default",
 		},
@@ -69,11 +68,11 @@ func TestConfigurationReconcile(t *testing.T) {
 	}
 
 	provider := &v1beta1.Provider{
-		TypeMeta: metav1.TypeMeta{
+		TypeMeta: v1.TypeMeta{
 			APIVersion: "terraform.core.oam.dev/v1beta2",
 			Kind:       "Provider",
 		},
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "default",
 			Namespace: "default",
 		},
@@ -98,7 +97,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	})
 	variables := &runtime.RawExtension{Raw: data}
 	configuration2 := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "a",
 			Namespace: "b",
 		},
@@ -129,7 +128,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	defer patches.Reset()
 
 	applyingJob2 := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      req.Name + "-" + string(types.TerraformApply),
 			Namespace: req.Namespace,
 		},
@@ -141,7 +140,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	stateData, _ := base64.StdEncoding.DecodeString("H4sIAAAAAAAA/4SQzarbMBCF934KoXUdPKNf+1VKCWNp5AocO8hyaSl592KlcBd3cZfnHPHpY/52QshfXI68b3IS+tuVK5dCaS+P+8ci4TbcULb94JJplZPAFte8MS18PQrKBO8Q+xk59SHa1AMA9M4YmoN3FGJ8M/azPs96yElcCkLIsG+V8sblnqOc3uXlRuvZ0GxSSuiCRUYbw2gGHRFGPxitEgJYQDQ0a68I2ChNo1cAZJ2bR20UtW8bsv55NuJRS94W2erXe5X5QQs3A/FZ4fhJaOwUgZTVMRjto1HGpSGSQuuD955hdDDPcR6NY1ZpQJ/YwagTRAvBpsi8LXn7Pa1U+ahfWHX/zWThYz9L4Otg3390r+5fAAAA//8hmcuNuQEAAA==")
 
 	backendSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-a",
 			Namespace: "vela-system",
 		},
@@ -152,7 +151,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	}
 
 	variableSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf(types.TFVariableSecret, req.Name),
 			Namespace: req.Namespace,
 		},
@@ -168,7 +167,7 @@ func TestConfigurationReconcile(t *testing.T) {
 
 	time := v1.NewTime(time.Now())
 	configuration3 := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:              "a",
 			Namespace:         "b",
 			DeletionTimestamp: &time,
@@ -183,7 +182,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	}
 
 	destroyJob3 := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "a-destroy",
 			Namespace: req.Namespace,
 		},
@@ -196,7 +195,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	r3.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(secret, provider, configuration3, destroyJob3).Build()
 
 	configuration4 := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:              "a",
 			Namespace:         "b",
 			DeletionTimestamp: &time,
@@ -224,7 +223,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	}
 
 	destroyJob4 := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "a-destroy",
 			Namespace: req.Namespace,
 		},
@@ -237,7 +236,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	r4.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(secret, provider, configuration4, destroyJob4, backendSecret).Build()
 
 	configuration5 := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:              "a",
 			Namespace:         "b",
 			DeletionTimestamp: &time,
@@ -253,7 +252,7 @@ func TestConfigurationReconcile(t *testing.T) {
 	}
 
 	destroyJob5 := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "a-destroy",
 			Namespace: req.Namespace,
 		},
@@ -267,7 +266,7 @@ func TestConfigurationReconcile(t *testing.T) {
 
 	// @step: create the setup for the job namespace tests
 	configuration6 := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:       "a",
 			Namespace:  "b",
 			Finalizers: []string{configurationFinalizer},
@@ -278,7 +277,7 @@ func TestConfigurationReconcile(t *testing.T) {
 		},
 	}
 
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "builds"}}
+	namespace := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "builds"}}
 	r6 := &ConfigurationReconciler{ControllerNamespace: "builds"}
 	r6.Client = fake.NewClientBuilder().
 		WithScheme(s).
@@ -305,7 +304,7 @@ terraform {
 	}
 	varMap := map[string]string{"name": "abc"}
 	appliedEnvVariable := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf(types.TFVariableSecret, req.Name),
 			Namespace: req.Namespace,
 		},
@@ -320,7 +319,7 @@ terraform {
 	}
 	appliedJobName := req.Name + "-" + string(types.TerraformApply)
 	appliedJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      appliedJobName,
 			Namespace: req.Namespace,
 			UID:       "111",
@@ -331,7 +330,7 @@ terraform {
 	}
 	varData, _ := json.Marshal(varMap)
 	configuration7 := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "a",
 			Namespace: "b",
 		},
@@ -478,7 +477,7 @@ func TestInitTFConfigurationMetaWithJobEnv(t *testing.T) {
 	}
 	credentials, err := json.Marshal(&ak)
 	secret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "default",
 			Namespace: "default",
 		},
@@ -488,11 +487,11 @@ func TestInitTFConfigurationMetaWithJobEnv(t *testing.T) {
 		Type: corev1.SecretTypeOpaque,
 	}
 	provider := v1beta1.Provider{
-		TypeMeta: metav1.TypeMeta{
+		TypeMeta: v1.TypeMeta{
 			APIVersion: "terraform.core.oam.dev/v1beta2",
 			Kind:       "Provider",
 		},
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "default",
 			Namespace: "default",
 		},
@@ -1124,7 +1123,7 @@ func TestTerraformDestroy(t *testing.T) {
 	rbacv1.AddToScheme(s)
 	// this is default provider if not specified in configuration.spec.providerRef
 	baseProvider := &v1beta1.Provider{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "default",
 			Namespace: "default",
 		},
@@ -1135,7 +1134,7 @@ func TestTerraformDestroy(t *testing.T) {
 	notReadyProvider.Status.State = types.ProviderIsNotReady
 
 	baseApplyJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      applyJobName,
 			Namespace: controllerNamespace,
 		},
@@ -1144,7 +1143,7 @@ func TestTerraformDestroy(t *testing.T) {
 	applyJobInLegacyNS.Namespace = legacyNamespace
 
 	baseDestroyJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      destroyJobName,
 			Namespace: controllerNamespace,
 		},
@@ -1154,31 +1153,31 @@ func TestTerraformDestroy(t *testing.T) {
 
 	// Resources to be GC
 	baseConfigurationCM := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
+		TypeMeta: v1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
 		},
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      configurationCMName,
 			Namespace: controllerNamespace,
 		},
 	}
 	baseVariableSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf(types.TFVariableSecret, secretSuffix),
 			Namespace: controllerNamespace,
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
 	connectionSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      connectionSecretName,
 			Namespace: connectionSecretNS,
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
 	backendSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf("tfstate-default-%s", secretSuffix),
 			Namespace: "default",
 		},
@@ -1215,7 +1214,7 @@ func TestTerraformDestroy(t *testing.T) {
 	metaWithDeleteResourceIsFalse.DeleteResource = false
 
 	baseConfiguration := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "base-conf",
 			Namespace: "default",
 		},
@@ -1231,7 +1230,7 @@ func TestTerraformDestroy(t *testing.T) {
 		Namespace: "default",
 	}
 	forceDeleteConfiguration := baseConfiguration.DeepCopy()
-	forceDeleteConfiguration.Spec.ForceDelete = pointer.Bool(true)
+	forceDeleteConfiguration.Spec.ForceDelete = ptr.To(true)
 
 	type args struct {
 		namespace     string

--- a/controllers/process/process_test.go
+++ b/controllers/process/process_test.go
@@ -22,11 +22,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -136,7 +135,7 @@ func TestInitTFConfigurationMetaWithDeleteResource(t *testing.T) {
 					Name: "abc",
 				},
 				Spec: v1beta2.ConfigurationSpec{
-					DeleteResource: pointer.Bool(true),
+					DeleteResource: ptr.To(true),
 				},
 			},
 			meta: &TFConfigurationMeta{
@@ -150,7 +149,7 @@ func TestInitTFConfigurationMetaWithDeleteResource(t *testing.T) {
 					Name: "abc",
 				},
 				Spec: v1beta2.ConfigurationSpec{
-					DeleteResource: pointer.Bool(false),
+					DeleteResource: ptr.To(false),
 				},
 			},
 			meta: &TFConfigurationMeta{
@@ -882,7 +881,7 @@ func TestIsTFStateGenerated(t *testing.T) {
 	}
 
 	secret2 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-a",
 			Namespace: "default",
 		},
@@ -899,7 +898,7 @@ func TestIsTFStateGenerated(t *testing.T) {
 
 	tfStateData3, _ := base64.StdEncoding.DecodeString("H4sIAAAAAAAA/0SMwa7CIBBF9/0KMutH80ArDb9ijKHDYEhqMQO4afrvBly4POfc3H0QAt7EOaYNrDj/NS7E7ELi5/1XQI3/o4beM3F0K1ihO65xI/egNsLThLPRWi6agkR/CVIppaSZJrfgbBx6//1ItbxqyWDFfnTBlFNlpKaut+EYPgEAAP//xUXpvZsAAAA=")
 	secret3 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-a",
 			Namespace: "default",
 		},
@@ -919,7 +918,7 @@ func TestIsTFStateGenerated(t *testing.T) {
 
 	tfStateData4, _ := base64.StdEncoding.DecodeString("H4sIAAAAAAAA/4SQzarbMBCF934KoXUdPKNf+1VKCWNp5AocO8hyaSl592KlcBd3cZfnHPHpY/52QshfXI68b3IS+tuVK5dCaS+P+8ci4TbcULb94JJplZPAFte8MS18PQrKBO8Q+xk59SHa1AMA9M4YmoN3FGJ8M/azPs96yElcCkLIsG+V8sblnqOc3uXlRuvZ0GxSSuiCRUYbw2gGHRFGPxitEgJYQDQ0a68I2ChNo1cAZJ2bR20UtW8bsv55NuJRS94W2erXe5X5QQs3A/FZ4fhJaOwUgZTVMRjto1HGpSGSQuuD955hdDDPcR6NY1ZpQJ/YwagTRAvBpsi8LXn7Pa1U+ahfWHX/zWThYz9L4Otg3390r+5fAAAA//8hmcuNuQEAAA==")
 	secret4 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-a",
 			Namespace: "default",
 		},
@@ -1014,7 +1013,7 @@ func TestGetTFOutputs(t *testing.T) {
 	}
 
 	secret2 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-a",
 			Namespace: "default",
 		},
@@ -1040,7 +1039,7 @@ func TestGetTFOutputs(t *testing.T) {
 	}
 
 	secret3 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-b",
 			Namespace: "default",
 		},
@@ -1059,7 +1058,7 @@ func TestGetTFOutputs(t *testing.T) {
 	}
 
 	secret4 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-c",
 			Namespace: "default",
 		},
@@ -1086,7 +1085,7 @@ func TestGetTFOutputs(t *testing.T) {
 	}
 
 	secret5 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-d",
 			Namespace: "default",
 		},
@@ -1096,7 +1095,7 @@ func TestGetTFOutputs(t *testing.T) {
 		},
 	}
 	oldConnectionSecret5 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "connection-secret-d",
 			Namespace: "default",
 			Labels: map[string]string{
@@ -1104,7 +1103,7 @@ func TestGetTFOutputs(t *testing.T) {
 				"terraform.core.oam.dev/owned-by":   "configuration5",
 			},
 		},
-		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
+		TypeMeta: v1.TypeMeta{Kind: "Secret"},
 		Data: map[string][]byte{
 			"container_id": []byte("something"),
 		},
@@ -1130,7 +1129,7 @@ func TestGetTFOutputs(t *testing.T) {
 	}
 
 	secret6 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-e",
 			Namespace: "default",
 		},
@@ -1140,7 +1139,7 @@ func TestGetTFOutputs(t *testing.T) {
 		},
 	}
 	oldConnectionSecret6 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "connection-secret-e",
 			Namespace: "default",
 			Labels: map[string]string{
@@ -1149,7 +1148,7 @@ func TestGetTFOutputs(t *testing.T) {
 				"terraform.core.oam.dev/owned-namespace": "default",
 			},
 		},
-		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
+		TypeMeta: v1.TypeMeta{Kind: "Secret"},
 		Data: map[string][]byte{
 			"container_id": []byte("something"),
 		},
@@ -1175,10 +1174,10 @@ func TestGetTFOutputs(t *testing.T) {
 		},
 	}
 
-	namespaceA := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "a"}}
-	namespaceB := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "b"}}
+	namespaceA := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "a"}}
+	namespaceB := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "b"}}
 	secret7 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-f",
 			Namespace: "a",
 		},
@@ -1188,7 +1187,7 @@ func TestGetTFOutputs(t *testing.T) {
 		},
 	}
 	oldConnectionSecret7 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "connection-secret-e",
 			Namespace: "default",
 			Labels: map[string]string{
@@ -1197,7 +1196,7 @@ func TestGetTFOutputs(t *testing.T) {
 				"terraform.core.oam.dev/owned-namespace": "a",
 			},
 		},
-		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
+		TypeMeta: v1.TypeMeta{Kind: "Secret"},
 		Data: map[string][]byte{
 			"container_id": []byte("something"),
 		},
@@ -1224,7 +1223,7 @@ func TestGetTFOutputs(t *testing.T) {
 	}
 
 	secret8 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfstate-default-d",
 			Namespace: "default",
 		},
@@ -1234,14 +1233,14 @@ func TestGetTFOutputs(t *testing.T) {
 		},
 	}
 	oldConnectionSecret8 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "connection-secret-d",
 			Namespace: "default",
 			Labels: map[string]string{
 				"terraform.core.oam.dev/created-by": "terraform-controller",
 			},
 		},
-		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
+		TypeMeta: v1.TypeMeta{Kind: "Secret"},
 		Data: map[string][]byte{
 			"container_id": []byte("something"),
 		},
@@ -1394,7 +1393,7 @@ func TestUpdateApplyStatus(t *testing.T) {
 	v1beta2.AddToScheme(s)
 
 	configuration := &v1beta2.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:       "a",
 			Namespace:  "b",
 			Generation: int64(1),
@@ -1463,7 +1462,7 @@ func TestAssembleAndTriggerJob(t *testing.T) {
 		Namespace: "b",
 	}
 
-	patches := gomonkey.ApplyFunc(apiutil.GVKForObject, func(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
+	patches := gomonkey.ApplyFunc(apiutil.GVKForObject, func(_ runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
 		return schema.GroupVersionKind{}, apierrors.NewNotFound(schema.GroupResource{}, "")
 	})
 	defer patches.Reset()
@@ -1504,7 +1503,7 @@ func TestCheckWhetherConfigurationChanges(t *testing.T) {
 	}
 	ctx := context.Background()
 	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "a",
 			Namespace: "b",
 		},
@@ -1594,8 +1593,8 @@ func TestGetApplyJob(t *testing.T) {
 		controllerNamespace = "ctrl-ns"
 		applyJobName        = "configuraion-apply"
 		jobNamespace        = "configuration-ns"
-		//legacyApplyJobName  = "legacy-job-name"
-		//legacyJobNamespace  = "legacy-job-ns"
+		// legacyApplyJobName  = "legacy-job-name"
+		// legacyJobNamespace  = "legacy-job-ns"
 	)
 
 	ctx := context.Background()
@@ -1608,13 +1607,13 @@ func TestGetApplyJob(t *testing.T) {
 		ControllerNamespace: jobNamespace,
 	}
 	baseJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      applyJobName,
 			Namespace: jobNamespace,
 		},
 	}
 	jobInCtrlNS := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      applyJobNameWithUID,
 			Namespace: controllerNamespace,
 		},
@@ -1710,7 +1709,7 @@ func TestRenderConfiguration(t *testing.T) {
 			name: "backend is not nil, configuration is hcl",
 			args: args{
 				configuration: &v1beta2.Configuration{
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: v1.ObjectMeta{
 						Namespace: "n1",
 					},
 					Spec: v1beta2.ConfigurationSpec{
@@ -1751,7 +1750,7 @@ terraform {
 			name: "backend is nil, configuration is remote",
 			args: args{
 				configuration: &v1beta2.Configuration{
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: v1.ObjectMeta{
 						Namespace: "n2",
 					},
 					Spec: v1beta2.ConfigurationSpec{
@@ -1804,7 +1803,7 @@ terraform {
 					Spec: v1beta2.ConfigurationSpec{
 						Backend: nil,
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: v1.ObjectMeta{
 						UID:       "xxxx-xxxx",
 						Namespace: "n2",
 						Name:      "name",

--- a/controllers/provider/credentials_test.go
+++ b/controllers/provider/credentials_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/agiledragon/gomonkey/v2"
+	gomonkey "github.com/agiledragon/gomonkey/v2"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jinzhu/copier"
@@ -21,6 +21,9 @@ import (
 	types "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 	"github.com/oam-dev/terraform-controller/api/v1beta1"
 )
+
+// wrongDataSecretName is the name used for invalid secret references in tests.
+const wrongDataSecretName = "wrong-data"
 
 func TestCheckAlibabaCloudCredentials(t *testing.T) {
 	type credentials struct {
@@ -109,7 +112,7 @@ func TestGetProviderCredentials(t *testing.T) {
 	}
 	assert.Nil(t, k8sClient1.Create(ctx, secret))
 
-	patches := ApplyMethod(reflect.TypeOf(&sts.Client{}), "GetCallerIdentity", func(_ *sts.Client, request *sts.GetCallerIdentityRequest) (response *sts.GetCallerIdentityResponse, err error) {
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&sts.Client{}), "GetCallerIdentity", func(_ *sts.Client, request *sts.GetCallerIdentityRequest) (response *sts.GetCallerIdentityResponse, err error) {
 		response = nil
 		err = nil
 		return
@@ -196,7 +199,7 @@ func TestGetProviderCredentials(t *testing.T) {
 	// alibaba provider with wrong data
 	secret3 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -209,13 +212,13 @@ func TestGetProviderCredentials(t *testing.T) {
 
 	var alibabaProvider v1beta1.Provider
 	copier.CopyWithOption(&alibabaProvider, &defaultProvider, copier.Option{DeepCopy: true})
-	alibabaProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	alibabaProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	// baidu cloud provider with wrong data
 	var baiduProvider2 v1beta1.Provider
 	copier.CopyWithOption(&baiduProvider2, &defaultProvider, copier.Option{DeepCopy: true})
 	baiduProvider2.Spec.Provider = string(baidu)
-	baiduProvider2.Spec.Credentials.SecretRef.Name = "wrong-data"
+	baiduProvider2.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -426,7 +429,7 @@ func TestGetProviderCredentials4EC(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -439,7 +442,7 @@ func TestGetProviderCredentials4EC(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -526,7 +529,7 @@ func TestGetProviderCredentials4VSphere(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -539,7 +542,7 @@ func TestGetProviderCredentials4VSphere(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -627,7 +630,7 @@ func TestGetProviderCredentials4TencentCloud(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -640,7 +643,7 @@ func TestGetProviderCredentials4TencentCloud(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -810,7 +813,7 @@ func TestGetProviderCredentials4UCloud(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -823,7 +826,7 @@ func TestGetProviderCredentials4UCloud(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -912,7 +915,7 @@ func TestGetProviderCredentials4GCP(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -925,7 +928,7 @@ func TestGetProviderCredentials4GCP(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -1014,7 +1017,7 @@ func TestGetProviderCredentials4AWS(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -1027,7 +1030,7 @@ func TestGetProviderCredentials4AWS(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -1118,7 +1121,7 @@ func TestGetProviderCredentials4Azure(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -1131,7 +1134,7 @@ func TestGetProviderCredentials4Azure(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -1204,7 +1207,7 @@ func TestGetProviderCredentials4Custom(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -1217,7 +1220,7 @@ func TestGetProviderCredentials4Custom(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider
@@ -1292,7 +1295,7 @@ func TestGetProviderCredentials4HuaweiCloud(t *testing.T) {
 
 	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wrong-data",
+			Name:      wrongDataSecretName,
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -1305,7 +1308,7 @@ func TestGetProviderCredentials4HuaweiCloud(t *testing.T) {
 
 	var badProvider v1beta1.Provider
 	copier.CopyWithOption(&badProvider, &provider, copier.Option{DeepCopy: true})
-	badProvider.Spec.Credentials.SecretRef.Name = "wrong-data"
+	badProvider.Spec.Credentials.SecretRef.Name = wrongDataSecretName
 
 	type args struct {
 		provider  v1beta1.Provider

--- a/controllers/provider_controller_test.go
+++ b/controllers/provider_controller_test.go
@@ -241,9 +241,7 @@ func TestReconcileProviderIsReadyButFailedToUpdateStatus(t *testing.T) {
 	r2.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(secret2, provider2).Build()
 
 	patches := ApplyFunc(apiutil.GVKForObject, func(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
-		switch obj.(type) {
-		case *v1beta1.Provider:
-			p := obj.(*v1beta1.Provider)
+		if p, ok := obj.(*v1beta1.Provider); ok {
 			if p.Status.State != "" {
 				return obj.GetObjectKind().GroupVersionKind(), errors.New("xxx")
 			}
@@ -324,9 +322,7 @@ func TestReconcile3(t *testing.T) {
 	r3.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(provider3).Build()
 
 	patches := ApplyFunc(apiutil.GVKForObject, func(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
-		switch obj.(type) {
-		case *v1beta1.Provider:
-			p := obj.(*v1beta1.Provider)
+		if p, ok := obj.(*v1beta1.Provider); ok {
 			if p.Status.State != "" {
 				return obj.GetObjectKind().GroupVersionKind(), errors.New("xxx")
 			}
@@ -378,9 +374,7 @@ func TestReconcile3(t *testing.T) {
 }
 
 func apiutilGVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
-	switch obj.(type) {
-	case *v1beta1.Provider:
-		p := obj.(*v1beta1.Provider)
+	if p, ok := obj.(*v1beta1.Provider); ok {
 		if p.Status.State != "" {
 			return obj.GetObjectKind().GroupVersionKind(), errors.New("xxx")
 		}

--- a/controllers/terraform/logging_test.go
+++ b/controllers/terraform/logging_test.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -123,7 +122,7 @@ func TestFlushStream(t *testing.T) {
 		{
 			name: "Flush stream",
 			args: args{
-				rc:   ioutil.NopCloser(strings.NewReader("xxx")),
+				rc:   io.NopCloser(strings.NewReader("xxx")),
 				name: "p1",
 			},
 			want: want{},
@@ -164,7 +163,7 @@ func TestStripColor(t *testing.T) {
 		},
 		"with color": {
 			args: args{
-				log: `[1mFailed`,
+				log: "\x1b[1mFailed",
 			},
 			want: want{
 				newLog: "Failed",

--- a/e2e/normal/configuration_test.go
+++ b/e2e/normal/configuration_test.go
@@ -448,7 +448,7 @@ func TestAllowDeleteProvisioningResoruce(t *testing.T) {
 
 }
 
-//func TestBasicConfigurationRegression(t *testing.T) {
+// func TestBasicConfigurationRegression(t *testing.T) {
 //	var retryTimes = 120
 //
 //	klog.Info("0. Create namespace")


### PR DESCRIPTION
## Summary
- clean up several linter issues
- use a constant for repeated test secret name
- replace deprecated io/ioutil usage
- reduce single-case switch statements
- fix comment formatting and remove dot imports

## Testing
- `make lint` *(fails: typecheck due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685cf360ffb8832aa6583c0f9d830480