### PR TITLE
Fix failing unit tests

### DIFF
--- a/controllers/configuration/convert_test.go
+++ b/controllers/configuration/convert_test.go
@@ -96,7 +96,7 @@ func TestRawExtension2Map2(t *testing.T) {
 				},
 			},
 			want: want{
-				errMessage: "invalid character 'x' looking for beginning of value",
+				errMessage: "cannot convert RawExtension with unrecognized content type to unstructured",
 			},
 		}}
 	for name, tc := range cases {

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -172,6 +172,7 @@ func TestConfigurationReconcile(t *testing.T) {
 			Name:              "a",
 			Namespace:         "b",
 			DeletionTimestamp: &time,
+			Finalizers:        []string{configurationFinalizer},
 		},
 		Spec: v1beta2.ConfigurationSpec{
 			HCL: "c",

--- a/controllers/provider/credentials_test.go
+++ b/controllers/provider/credentials_test.go
@@ -109,10 +109,8 @@ func TestGetProviderCredentials(t *testing.T) {
 	}
 	assert.Nil(t, k8sClient1.Create(ctx, secret))
 
-	patches := ApplyMethod(reflect.TypeOf(&sts.Client{}), "GetCallerIdentity", func(_ *sts.Client, request *sts.GetCallerIdentityRequest) (response *sts.GetCallerIdentityResponse, err error) {
-		response = nil
-		err = nil
-		return
+	patches := ApplyFunc(checkAlibabaCloudCredentials, func(region, accessKeyID, accessKeySecret, stsToken string) error {
+		return nil
 	})
 	defer patches.Reset()
 

--- a/controllers/terraform/logging_test.go
+++ b/controllers/terraform/logging_test.go
@@ -89,7 +89,7 @@ func TestGetPodLog(t *testing.T) {
 				initContainerName: "terraform-init",
 			},
 			want: want{
-				errMsg: "can not be accept",
+				errMsg: "client rate limiter Wait returned an error: can not be accept",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- set finalizer for fake configuration object
- align expected error messages with updated Go components
- use a simpler function patch in credential tests

## Testing
- `make test` *(fails: Get "https://proxy.golang.org/sigs.k8s.io/controller-tools/cmd/controller-gen/@v/v0.16.5.info": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866043a41f8832a9204e679d61c14bf